### PR TITLE
Enhance Drupal installation with async and poll

### DIFF
--- a/devops/reinstall/profile_workflow.yml
+++ b/devops/reinstall/profile_workflow.yml
@@ -32,4 +32,7 @@
 - name: Installing drupal
   become: yes
   shell: "{{ php_env_vars }} drush -y si {{ installation_profile_name }} {{ openy_profile_install_settings }} openy_terms_of_use.agree_openy_terms=1 install_configure_form.enable_update_status_emails=NULL --db-url=mysql://{{ mysql_user }}:{{ mysql_pass }}@127.0.0.1:/{{ mysql_db }} --account-name={{ drupal_user }} --account-pass={{ drupal_pass }} --uri={{ site_url }}"
+  async: 7200 # 2 hour limit
+  poll: 5
   when: run_installation_process
+


### PR DESCRIPTION
Added async and poll parameters to the Drupal installation task. Should prevent infinity wait task when connection lose or ansible is freeze on the remote machine.