### PR TITLE
Modify database update process in sql_workflow.yml

### DIFF
--- a/devops/reinstall/sql_workflow.yml
+++ b/devops/reinstall/sql_workflow.yml
@@ -52,20 +52,15 @@
   shell: "{{ php_env_vars }} drush -y rr -l {{ site_url }} || true"
   when: rebuild_registry
 
-- name: Clear Drupal cache
-  ignore_errors: yes
-  become: yes
-  shell: "{{ php_env_vars }} drush cr -l {{ site_url }}"
-
-- name: Clear Drupal cache
-  become: yes
-  shell: "{{ php_env_vars }} drush cr -l {{ site_url }}"
-
 # Update database. See https://www.youtube.com/watch?v=vFsgNjhGr4Y how-to update configs with http://dgo.to/confi
 - name: Updating database
   become: yes
-  shell: "{{ php_env_vars }} drush -y updb -l {{ site_url }}"
+  shell: "{{ php_env_vars }} drush -y updb --no-cache-clear -l {{ site_url }}"
   register: updates
+
+- name: Clear Drupal cache
+  become: yes
+  shell: "{{ php_env_vars }} drush cr -l {{ site_url }}"
 
 - name: Download stage file proxy
   ignore_errors: yes


### PR DESCRIPTION
## Summary

Reorders the database update workflow to fix compatibility with Drupal 11.1+ schema changes.

## Problem

When upgrading to Drupal 11.1+, running `drush cr` before `drush updb` fails because the code expects new database columns (e.g., `router.alias`) that don't exist yet in the database schema. This causes fatal errors like:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'alias' in 'INSERT INTO'
```

## Solution

1. **Run `updb` first** with `--no-cache-clear` flag - this updates the database schema before cache rebuild attempts to use new columns
2. **Run `cr` after** - cache rebuild now works because schema is up-to-date

## Changes

- Removed redundant first cache clear (was failing anyway on schema mismatch)
- Added `--no-cache-clear` flag to `drush updb` command
- Reordered tasks: `updb` → `cr` instead of `cr` → `updb`

## References

- [Drush updatedb documentation](https://www.drush.org/12.x/commands/updatedb/)
- [Drupal upgrade guide](https://www.drupal.org/docs/upgrading-drupal)